### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -2,7 +2,7 @@ class MarketsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @markets = Market.all.order("created_at DESC")
+    @markets = Market.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -2,6 +2,7 @@ class MarketsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
+    @markets = Market.all.order("created_at DESC")
   end
 
   def new

--- a/app/models/market.rb
+++ b/app/models/market.rb
@@ -21,5 +21,8 @@ class Market < ApplicationRecord
                             message: "can't be blank" }
 
   belongs_to :user
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :shipping_price
   # has_one :order_recode
 end

--- a/app/models/shipping_price.rb
+++ b/app/models/shipping_price.rb
@@ -7,6 +7,4 @@ class ShippingPrice < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :markets
-
-
 end

--- a/app/models/shipping_price.rb
+++ b/app/models/shipping_price.rb
@@ -4,4 +4,9 @@ class ShippingPrice < ActiveHash::Base
     { id: 2, name: '着払い(購入者負担)' },
     { id: 3, name: '送料込み(出品者負担)' }
   ]
+
+  include ActiveHash::Associations
+  has_many :markets
+
+
 end

--- a/app/views/markets/index.html.erb
+++ b/app/views/markets/index.html.erb
@@ -128,11 +128,13 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
+      <% if @markets.present? %>
+      <% @markets.each do |market| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to markets_path(market.id) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img"  %>
+          <%= image_tag market.image, class: "item-img"  %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,10 +145,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= market.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= market.price %>円<br><%= market.shipping_price.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +157,12 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
+      
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -179,6 +183,7 @@
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
+    <% end %>
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/markets/index.html.erb
+++ b/app/views/markets/index.html.erb
@@ -127,12 +127,10 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      
       <% if @markets.present? %>
       <% @markets.each do |market| %>
       <li class='list'>
-        <%= link_to markets_path(market.id) do %>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag market.image, class: "item-img"  %>
 
@@ -159,9 +157,6 @@
       </li>
       <% end %>
       
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <% else %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -180,11 +175,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
     <% end %>
   </div>
+
   <%# /商品一覧 %>
 </div>
 <%= link_to(new_market_path, class: 'purchase-btn') do %>


### PR DESCRIPTION
# WHY
登録して出品された商品を一覧表示する機能を実装しました

# WHAT
商品は制限なく誰でも見れる状態で表示されていますが、出品されている商品が空の場合は、条件分岐でダミーが表示されるようになっています。
一覧表示は、出品日時が新しい順に表示されるようにして、各商品については、「画像・商品名・価格・配送料の負担」の4つの情報が表示される仕様になっています。
売却済みの商品がある場合は、商品の画像上に『sold out』の文字が表示されるようにしたいのですが、商品購入機能を実装していないので、現段階ではしていません。

よろしくお願いします。


#  GYAZO動画
'''
商品のデータがない場合は、ダミー商品が表示されている動画
'''
https://gyazo.com/917250fe99e7f5fae18f3e7221890a1c

'''
商品のデータがある場合は、商品が一覧で表示されている動画
'''
https://gyazo.com/8c73cf1908c9a35733584421b0f8d19f